### PR TITLE
modify check of the environment variable

### DIFF
--- a/lib/jekyll-amazon/amazon_tag.rb
+++ b/lib/jekyll-amazon/amazon_tag.rb
@@ -24,7 +24,7 @@ module Jekyll
       }.freeze
 
       ECS_ASSOCIATE_TAG = ENV['ECS_ASSOCIATE_TAG'] || ''
-      AWS_ACCESS_KEY_ID = ENV['AWS_ACCESS_KEY'] || ''
+      AWS_ACCESS_KEY_ID = ENV['AWS_ACCESS_KEY_ID'] || ''
       AWS_SECRET_KEY = ENV['AWS_SECRET_KEY'] || ''
 
       raise 'AWS_ACCESS_KEY_ID env variable is not set' if AWS_ACCESS_KEY_ID.empty?


### PR DESCRIPTION
The document has been instructs to set the environment variable as follows

```
export AWS_ACCESS_KEY_ID=...
```

However variables being checked are different.

```
AWS_ACCESS_KEY_ID = ENV['AWS_ACCESS_KEY'] || ''
```

Therefore, it was modify this.
